### PR TITLE
Playing local files with no extension in name causes data loss

### DIFF
--- a/Source/CachingPlayerItem.swift
+++ b/Source/CachingPlayerItem.swift
@@ -172,9 +172,9 @@ public final class CachingPlayerItem: AVPlayerItem {
             self.url = url.appendingPathExtension(fileExtension)
 
             // Removes old SymLinks which cause issues
-            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: self.url)
 
-            try? FileManager.default.createSymbolicLink(at: url, withDestinationURL: filePathURL)
+            try? FileManager.default.createSymbolicLink(at: self.url, withDestinationURL: filePathURL)
         } else {
             assert(filePathURL.pathExtension.isEmpty == false,
                    "CachingPlayerItem error: filePathURL pathExtension empty, pass the extension in `fileExtension` parameter")


### PR DESCRIPTION
A local variable `url` is used instead of `self.url` to create a symbolic link. `url` contains the input `filePathURL` minus the extension, but if you pass in a file with no extension in the path then `url` has the same value as `filePathURL`. A symbolic link from `url` to `filePathURL` is then created, meaning we overwrite the input file with a symbolic link to itself causing data loss and we are unable to play as the symbolic link is recursive.

#### Example
```swift
let localFilePath = FileManager.default.urls(
    for: .cachesDirectory,
    in: .userDomainMask
).appendingPathComponent("example-filename-with-no-extension")!

let fileExtension = "FLAC"
let item = CachingPlayerItem(filePathURL: localFilePath, fileExtension: fileExtension)
```

#### Filesystem showing issue
```
$ ls -lahtr /Users/user/Library/Developer/CoreSimulator/Devices/337E1E6C-66A1-42EE-A387-DEC7AA018AE6/data/Containers/Data/Application/BB817909-7D35-4FA0-B16E-8C4C38B5D00D/Library/Caches
total 0
drwxr-xr-x  10 user  user   320B 20 Feb 16:40 ../
lrwxr-xr-x   1 user  user   241B 20 Feb 16:40 example-filename-with-no-extension -> /Users/user/Library/Developer/CoreSimulator/Devices/337E1E6C-66A1-42EE-A387-DEC7AA018AE6/data/Containers/Data/Application/BB817909-7D35-4FA0-B16E-8C4C38B5D00D/Library/Caches/example-filename-with-no-extension
```