### PR TITLE
Fix memory crash

### DIFF
--- a/Source/ResourceLoaderDelegate.swift
+++ b/Source/ResourceLoaderDelegate.swift
@@ -215,8 +215,13 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     private func writeBufferDataToFileIfNeeded(forced: Bool = false) {
         lock.lock()
         defer { lock.unlock() }
-
-        guard bufferData.count >= downloadBufferLimit || forced else { return }
+        guard 
+            let availableSpace = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false).resourceValues(forKeys: [.volumeAvailableCapacityKey]).volumeAvailableCapacity,
+            availableSpace > Int64(bufferData.count), 
+            bufferData.count >= downloadBufferLimit || force 
+        else {
+             return
+        }
 
         fileHandle.append(data: bufferData)
         bufferData = Data()


### PR DESCRIPTION
**Check available space before caching video**

I'm giving use to the key volumeAvailableCapacity to get the available space and then check if the data to write is small enough to save in the device, if not return

[Issue](https://github.com/sukov/CachingPlayerItem/issues/27#issue-2813667461).
